### PR TITLE
add missing CA for Let's Encrypt intermediate cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,21 @@ sources = isrgrootx1.signing_policy \
           letsencryptauthorityx4.signing_policy \
           lets-encrypt-r3.signing_policy \
           lets-encrypt-r4.signing_policy \
+          trustid-x3-root.signing_policy \
 
 targets = 23c2f850.signing_policy 4042bcee.signing_policy \
           4a0a35c0.signing_policy 4f06f81d.signing_policy \
           6187b673.signing_policy 929e297e.signing_policy \
           8d33f237.signing_policy dec71a0b.signing_policy \
           9f194ecd.signing_policy dd7d39a7.signing_policy \
+          12d55845.signing_policy 2e5ac55d.signing_policy \
           23c2f850.0 4042bcee.0 \
           4a0a35c0.0 4f06f81d.0 \
           6187b673.0 8d33f237.0 \
           929e297e.0 9f194ecd.0 \
           dec71a0b.0 dd7d39a7.0 \
-          isrgrootx1.pem \
+          12d55845.0 2e5ac55d.0 \
+          isrgrootx1.pem trustid-x3-root.pem \
           letsencryptauthorityx3.pem letsencryptauthorityx4.pem \
           lets-encrypt-r3.pem lets-encrypt-r4.pem
 
@@ -58,17 +61,25 @@ dec71a0b.signing_policy : lets-encrypt-r3.signing_policy
 	$(LINK) lets-encrypt-r3.signing_policy dec71a0b.signing_policy
 dd7d39a7.signing_policy : lets-encrypt-r4.signing_policy
 	$(LINK) lets-encrypt-r4.signing_policy dd7d39a7.signing_policy
+12d55845.signing_policy : trustid-x3-root.signing_policy
+	$(LINK) trustid-x3-root.signing_policy 12d55845.signing_policy
+2e5ac55d.signing_policy : trustid-x3-root.signing_policy
+	$(LINK) trustid-x3-root.signing_policy 2e5ac55d.signing_policy
 
 23c2f850.0 : letsencryptauthorityx4.pem
 	$(LINK) letsencryptauthorityx4.pem 23c2f850.0
 4042bcee.0 : isrgrootx1.pem
 	$(LINK) isrgrootx1.pem 4042bcee.0
+2e5ac55d.0 : trustid-x3-root.pem
+	$(LINK) trustid-x3-root.pem 2e5ac55d.0
 4a0a35c0.0 : letsencryptauthorityx3.pem
 	$(LINK) letsencryptauthorityx3.pem 4a0a35c0.0
 4f06f81d.0 : letsencryptauthorityx3.pem
 	$(LINK) letsencryptauthorityx3.pem 4f06f81d.0
 6187b673.0 : isrgrootx1.pem
 	$(LINK) isrgrootx1.pem 6187b673.0
+12d55845.0 : trustid-x3-root.pem
+	$(LINK) trustid-x3-root.pem 12d55845.0
 8d33f237.0 : lets-encrypt-r3.pem
 	$(LINK) lets-encrypt-r3.pem 8d33f237.0
 929e297e.0 : letsencryptauthorityx4.pem
@@ -82,6 +93,8 @@ dd7d39a7.0 : lets-encrypt-r4.pem
 
 isrgrootx1.pem :
 	$(GET) https://letsencrypt.org/certs/isrgrootx1.pem
+trustid-x3-root.pem :
+	$(GET) https://letsencrypt.org/certs/trustid-x3-root.pem
 lets-encrypt-r3.pem :
 	$(GET) https://letsencrypt.org/certs/lets-encrypt-r3.pem
 lets-encrypt-r4.pem :

--- a/trustid-x3-root.signing_policy
+++ b/trustid-x3-root.signing_policy
@@ -1,0 +1,3 @@
+access_id_CA   X509    '/C=US/O=Digital Signature Trust Co./CN=DST Root CA X3'
+pos_rights     globus  CA:sign
+cond_subjects  globus  '"/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X3" "/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X4" "/C=US/O=Let\'s Encrypt/CN=R3" "/C=US/O=Let\'s Encrypt/CN=R4"'


### PR DESCRIPTION
Dear CILogon team,

@brianhlin has requested that I submit this PR to pull in the DST Root CA X3 from https://letsencrypt.org/certificates/

Context from https://opensciencegrid.atlassian.net/browse/SOFTWARE-4436 :

>It seems to me that the intermediate CA[1] that signs the LE certs can be signed by 2 different CAs:
>1. /C=US/O=Internet Security Research Group/CN=ISRG Root X1
>2. O=Digital Signature Trust Co., CN=DST Root CA X3
>
>The first one is already in the latest version of `osg-ca-certs` but the second one is not.
>I've got a LE hostcert from tiger that had concatenated its intermediate certificate which was signed by 2) and since that CA was missing the cert wasn't trusted.
>
> Note: A workaround for this issue is to remove the intermediate certificate from the hostcert, this way the system will look for the intermediate cert[1] within `/etc/grid-security/certificates` and found the one that is signed by 1) instead.
>
> [1] C=US, O=Let's Encrypt, CN=R3

Let us know if this works for you or if there is anything we should do differently.

Thanks!
Carl