### PR TITLE
Remove expired ROOT CA X3 and ROOT CA X4 certificates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,16 @@
 sources = isrgrootx1.signing_policy \
-          letsencryptauthorityx4.signing_policy \
           lets-encrypt-r3.signing_policy \
           lets-encrypt-r4.signing_policy \
 
-targets = 23c2f850.signing_policy 4042bcee.signing_policy \
-          6187b673.signing_policy 929e297e.signing_policy \
+targets = 4042bcee.signing_policy \
+          6187b673.signing_policy \
           8d33f237.signing_policy dec71a0b.signing_policy \
           9f194ecd.signing_policy dd7d39a7.signing_policy \
-          23c2f850.0 4042bcee.0 \
+          4042bcee.0 \
           6187b673.0 8d33f237.0 \
-          929e297e.0 9f194ecd.0 \
+          9f194ecd.0 \
           dec71a0b.0 dd7d39a7.0 \
           isrgrootx1.pem \
-          letsencryptauthorityx4.pem \
           lets-encrypt-r3.pem lets-encrypt-r4.pem
 
 installfiles = $(targets) $(sources)
@@ -32,18 +30,16 @@ clean :
 	$(RM) $(targets) *.pem
 
 check : all
-	openssl verify -CApath . letsencryptauthorityx4.pem
+	openssl verify -CApath . isrgrootx1.pem
+	openssl verify -CApath . lets-encrypt-r3.pem
+	openssl verify -CApath . lets-encrypt-r4.pem
 
-23c2f850.signing_policy : letsencryptauthorityx4.signing_policy
-	$(LINK) letsencryptauthorityx4.signing_policy 23c2f850.signing_policy
 4042bcee.signing_policy : isrgrootx1.signing_policy
 	$(LINK) isrgrootx1.signing_policy 4042bcee.signing_policy
 6187b673.signing_policy : isrgrootx1.signing_policy
 	$(LINK) isrgrootx1.signing_policy 6187b673.signing_policy
 8d33f237.signing_policy : lets-encrypt-r3.signing_policy
 	$(LINK) lets-encrypt-r3.signing_policy 8d33f237.signing_policy
-929e297e.signing_policy : letsencryptauthorityx4.signing_policy
-	$(LINK) letsencryptauthorityx4.signing_policy 929e297e.signing_policy
 9f194ecd.signing_policy : lets-encrypt-r4.signing_policy
 	$(LINK) lets-encrypt-r4.signing_policy 9f194ecd.signing_policy
 dec71a0b.signing_policy : lets-encrypt-r3.signing_policy
@@ -51,16 +47,12 @@ dec71a0b.signing_policy : lets-encrypt-r3.signing_policy
 dd7d39a7.signing_policy : lets-encrypt-r4.signing_policy
 	$(LINK) lets-encrypt-r4.signing_policy dd7d39a7.signing_policy
 
-23c2f850.0 : letsencryptauthorityx4.pem
-	$(LINK) letsencryptauthorityx4.pem 23c2f850.0
 4042bcee.0 : isrgrootx1.pem
 	$(LINK) isrgrootx1.pem 4042bcee.0
 6187b673.0 : isrgrootx1.pem
 	$(LINK) isrgrootx1.pem 6187b673.0
 8d33f237.0 : lets-encrypt-r3.pem
 	$(LINK) lets-encrypt-r3.pem 8d33f237.0
-929e297e.0 : letsencryptauthorityx4.pem
-	$(LINK) letsencryptauthorityx4.pem 929e297e.0
 9f194ecd.0 : lets-encrypt-r4.pem
 	$(LINK) lets-encrypt-r4.pem 9f194ecd.0
 dec71a0b.0 : lets-encrypt-r3.pem
@@ -74,5 +66,3 @@ lets-encrypt-r3.pem :
 	$(GET) https://letsencrypt.org/certs/lets-encrypt-r3.pem
 lets-encrypt-r4.pem :
 	$(GET) https://letsencrypt.org/certs/lets-encrypt-r4.pem
-letsencryptauthorityx4.pem :
-	$(GET) https://letsencrypt.org/certs/letsencryptauthorityx4.pem

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,18 @@
 sources = isrgrootx1.signing_policy \
-          letsencryptauthorityx3.signing_policy \
           letsencryptauthorityx4.signing_policy \
           lets-encrypt-r3.signing_policy \
           lets-encrypt-r4.signing_policy \
 
 targets = 23c2f850.signing_policy 4042bcee.signing_policy \
-          4a0a35c0.signing_policy 4f06f81d.signing_policy \
           6187b673.signing_policy 929e297e.signing_policy \
           8d33f237.signing_policy dec71a0b.signing_policy \
           9f194ecd.signing_policy dd7d39a7.signing_policy \
           23c2f850.0 4042bcee.0 \
-          4a0a35c0.0 4f06f81d.0 \
           6187b673.0 8d33f237.0 \
           929e297e.0 9f194ecd.0 \
           dec71a0b.0 dd7d39a7.0 \
           isrgrootx1.pem \
-          letsencryptauthorityx3.pem letsencryptauthorityx4.pem \
+          letsencryptauthorityx4.pem \
           lets-encrypt-r3.pem lets-encrypt-r4.pem
 
 installfiles = $(targets) $(sources)
@@ -35,17 +32,12 @@ clean :
 	$(RM) $(targets) *.pem
 
 check : all
-	openssl verify -CApath . letsencryptauthorityx3.pem
 	openssl verify -CApath . letsencryptauthorityx4.pem
 
 23c2f850.signing_policy : letsencryptauthorityx4.signing_policy
 	$(LINK) letsencryptauthorityx4.signing_policy 23c2f850.signing_policy
 4042bcee.signing_policy : isrgrootx1.signing_policy
 	$(LINK) isrgrootx1.signing_policy 4042bcee.signing_policy
-4a0a35c0.signing_policy : letsencryptauthorityx3.signing_policy
-	$(LINK) letsencryptauthorityx3.signing_policy 4a0a35c0.signing_policy
-4f06f81d.signing_policy : letsencryptauthorityx3.signing_policy
-	$(LINK) letsencryptauthorityx3.signing_policy 4f06f81d.signing_policy
 6187b673.signing_policy : isrgrootx1.signing_policy
 	$(LINK) isrgrootx1.signing_policy 6187b673.signing_policy
 8d33f237.signing_policy : lets-encrypt-r3.signing_policy
@@ -63,10 +55,6 @@ dd7d39a7.signing_policy : lets-encrypt-r4.signing_policy
 	$(LINK) letsencryptauthorityx4.pem 23c2f850.0
 4042bcee.0 : isrgrootx1.pem
 	$(LINK) isrgrootx1.pem 4042bcee.0
-4a0a35c0.0 : letsencryptauthorityx3.pem
-	$(LINK) letsencryptauthorityx3.pem 4a0a35c0.0
-4f06f81d.0 : letsencryptauthorityx3.pem
-	$(LINK) letsencryptauthorityx3.pem 4f06f81d.0
 6187b673.0 : isrgrootx1.pem
 	$(LINK) isrgrootx1.pem 6187b673.0
 8d33f237.0 : lets-encrypt-r3.pem
@@ -86,7 +74,5 @@ lets-encrypt-r3.pem :
 	$(GET) https://letsencrypt.org/certs/lets-encrypt-r3.pem
 lets-encrypt-r4.pem :
 	$(GET) https://letsencrypt.org/certs/lets-encrypt-r4.pem
-letsencryptauthorityx3.pem :
-	$(GET) https://letsencrypt.org/certs/letsencryptauthorityx3.pem
 letsencryptauthorityx4.pem :
 	$(GET) https://letsencrypt.org/certs/letsencryptauthorityx4.pem

--- a/isrgrootx1.signing_policy
+++ b/isrgrootx1.signing_policy
@@ -1,3 +1,3 @@
 access_id_CA   X509    '/C=US/O=Internet Security Research Group/CN=ISRG Root X1'
 pos_rights     globus  CA:sign
-cond_subjects  globus  '"/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X4" "/C=US/O=Let\'s Encrypt/CN=R3" "/C=US/O=Let\'s Encrypt/CN=R4"'
+cond_subjects  globus  '"/C=US/O=Let\'s Encrypt/CN=R3" "/C=US/O=Let\'s Encrypt/CN=R4"'

--- a/isrgrootx1.signing_policy
+++ b/isrgrootx1.signing_policy
@@ -1,3 +1,3 @@
 access_id_CA   X509    '/C=US/O=Internet Security Research Group/CN=ISRG Root X1'
 pos_rights     globus  CA:sign
-cond_subjects  globus  '"/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X3" "/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X4" "/C=US/O=Let\'s Encrypt/CN=R3" "/C=US/O=Let\'s Encrypt/CN=R4"'
+cond_subjects  globus  '"/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X4" "/C=US/O=Let\'s Encrypt/CN=R3" "/C=US/O=Let\'s Encrypt/CN=R4"'

--- a/letsencryptauthorityx3.signing_policy
+++ b/letsencryptauthorityx3.signing_policy
@@ -1,3 +1,0 @@
-access_id_CA   X509    '/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X3'
-pos_rights     globus  CA:sign
-cond_subjects  globus  '"/CN=*"'

--- a/letsencryptauthorityx4.signing_policy
+++ b/letsencryptauthorityx4.signing_policy
@@ -1,3 +1,0 @@
-access_id_CA   X509    '/C=US/O=Let\'s Encrypt/CN=Let\'s Encrypt Authority X4'
-pos_rights     globus  CA:sign
-cond_subjects  globus  '"/CN=*"'


### PR DESCRIPTION
When building this on EL8, the self test failed because of expired certificates. There is no need to distribute expired roots. So, I removed them from the bundle.

I also added the other roots to the "check" step.